### PR TITLE
Check ClosePolicyViolation error instead of InternalServerErr

### DIFF
--- a/opentsdbfirehosenozzle/opentsdb_firehose_nozzle_test.go
+++ b/opentsdbfirehosenozzle/opentsdb_firehose_nozzle_test.go
@@ -215,46 +215,6 @@ var _ = Describe("OpenTSDB Firehose Nozzle", func() {
 
 	}, 2)
 
-	It("sends a server disconnected metric when the server disconnects abnormally", func(done Done) {
-		defer close(done)
-
-		for i := 0; i < 10; i++ {
-			envelope := events.Envelope{
-				Origin:    proto.String("origin"),
-				Timestamp: proto.Int64(1000000000),
-				EventType: events.Envelope_ValueMetric.Enum(),
-				ValueMetric: &events.ValueMetric{
-					Name:  proto.String(fmt.Sprintf("metricName-%d", i)),
-					Value: proto.Float64(float64(i)),
-					Unit:  proto.String("gauge"),
-				},
-				Deployment: proto.String("deployment-name"),
-				Job:        proto.String("doppler"),
-				Index:      proto.String("0"),
-			}
-			fakeFirehose.AddEvent(envelope)
-		}
-
-		fakeFirehose.SetCloseMessage(websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "Client did not respond to ping before keep-alive timeout expired."))
-
-		go nozzle.Start()
-
-		var contents []byte
-		Eventually(fakeOpenTSDB.ReceivedContents).Should(Receive(&contents))
-
-		var metrics []poster.Metric
-		err := json.Unmarshal(contents, &metrics)
-		Expect(err).ToNot(HaveOccurred())
-
-		slowConsumerMetric := findSlowConsumerMetric(metrics)
-		Expect(slowConsumerMetric).NotTo(BeNil())
-		Expect(slowConsumerMetric.Value).To(BeEquivalentTo(1))
-
-		Expect(logOutput).To(gbytes.Say("Error while reading from the firehose"))
-		Expect(logOutput).To(gbytes.Say("Client did not respond to ping before keep-alive timeout expired."))
-		Expect(logOutput).To(gbytes.Say("Disconnected because nozzle couldn't keep up."))
-	}, 2)
-
 	It("does not report slow consumer error when closed for other reasons", func(done Done) {
 		defer close(done)
 

--- a/opentsdbfirehosenozzle/opentsdb_firehose_nozzle_test.go
+++ b/opentsdbfirehosenozzle/opentsdb_firehose_nozzle_test.go
@@ -120,7 +120,7 @@ var _ = Describe("OpenTSDB Firehose Nozzle", func() {
 			fakeFirehose.AddEvent(envelope)
 		}
 
-		fakeFirehose.SetCloseMessage(websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "Client did not respond to ping before keep-alive timeout expired."))
+		fakeFirehose.SetCloseMessage(websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "Client did not respond to ping before keep-alive timeout expired."))
 
 		go nozzle.Start()
 
@@ -235,7 +235,7 @@ var _ = Describe("OpenTSDB Firehose Nozzle", func() {
 			fakeFirehose.AddEvent(envelope)
 		}
 
-		fakeFirehose.SetCloseMessage(websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "Client did not respond to ping before keep-alive timeout expired."))
+		fakeFirehose.SetCloseMessage(websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "Client did not respond to ping before keep-alive timeout expired."))
 
 		go nozzle.Start()
 


### PR DESCRIPTION
- We changed the [error code in loggregatorlib](https://github.com/cloudfoundry/loggregatorlib/commit/703cc26e7eac0b95502c7ea5a10b2088e89f7c6c) to more accurately
  describe the error when the client was falling behind.
- Use switch type assertion instead of reflection while inspecting
  error

[#101908874]